### PR TITLE
MissingStoreException.status multi-line FIX

### DIFF
--- a/src/main/java/walkingkooka/store/MissingStoreException.java
+++ b/src/main/java/walkingkooka/store/MissingStoreException.java
@@ -103,7 +103,9 @@ public class MissingStoreException extends StoreException
     public Optional<HttpStatus> status() {
         return Optional.of(
             HttpStatusCode.NOT_FOUND.setMessage(
-                this.getMessage()
+                HttpStatus.firstLineOfText(
+                    this.getMessage()
+                )
             )
         );
     }

--- a/src/test/java/walkingkooka/store/MissingStoreExceptionTest.java
+++ b/src/test/java/walkingkooka/store/MissingStoreExceptionTest.java
@@ -147,6 +147,17 @@ public final class MissingStoreExceptionTest implements StandardThrowableTesting
     }
 
     @Test
+    public void testHttpStatusWhenCustomMultiLineMessage() {
+        this.checkEquals(
+            Optional.of(
+                HttpStatusCode.NOT_FOUND.setMessage("Hello 111")
+            ),
+            new MissingStoreException("Hello 111\nHello 222\nHello 333")
+                .status()
+        );
+    }
+
+    @Test
     public void testHttpStatusWithHasNotFoundText() {
         this.checkEquals(
             Optional.of(


### PR DESCRIPTION
- Previous HttpStatus.setMessage would fail when given a multi-line String